### PR TITLE
framework: nil entries in map should be preserved

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -118,6 +118,17 @@ var encodingTests = []struct {
 		false,
 	},
 
+	{
+		"map with null value",
+		map[string]interface{}{
+			"foo": nil,
+		},
+		map[string]interface{}{
+			"foo": sdk.Null,
+		},
+		false,
+	},
+
 	//-----------------------------------------------------------
 	// Slice
 

--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -136,6 +136,58 @@ func TestImportGet(t *testing.T) {
 		},
 
 		{
+			"key get map",
+			&rootEmbedNamespace{&nsKeyValue{
+				Key: "foo",
+				Value: map[string]interface{}{
+					"bar": 42,
+				},
+			}},
+			[]*sdk.GetReq{
+				{
+					Keys:  []string{"foo"},
+					KeyId: 42,
+				},
+			},
+			[]*sdk.GetResult{
+				{
+					Keys:  []string{"foo"},
+					KeyId: 42,
+					Value: map[string]interface{}{
+						"bar": 42,
+					},
+				},
+			},
+			false,
+		},
+
+		{
+			"key get map with nil value",
+			&rootEmbedNamespace{&nsKeyValue{
+				Key: "foo",
+				Value: map[string]interface{}{
+					"bar": nil,
+				},
+			}},
+			[]*sdk.GetReq{
+				{
+					Keys:  []string{"foo"},
+					KeyId: 42,
+				},
+			},
+			[]*sdk.GetResult{
+				{
+					Keys:  []string{"foo"},
+					KeyId: 42,
+					Value: map[string]interface{}{
+						"bar": nil,
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"key get invalid",
 			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
 			[]*sdk.GetReq{

--- a/framework/reflect.go
+++ b/framework/reflect.go
@@ -79,6 +79,12 @@ func (m *Import) reflectMap(mv reflect.Value) (reflect.Value, error) {
 			return mv, err
 		}
 
+		// If the value isn't valid, we set the value of the map to
+		// the zero value for the proper type.
+		if !v.IsValid() {
+			v = reflect.Zero(mv.Type().Elem())
+		}
+
 		mv.SetMapIndex(k, v)
 	}
 


### PR DESCRIPTION
This fixes an issue where a null value in a map would get deleted because `SetMapIndex` with the zero reflect value as the value would _delete_ the map entry. 

To resolve this, for invalid values we set the value to the zero value of the _type_ (not the zero value of the `reflect.Value`) which sets the proper value.