### PR TITLE
framework: Report keys properly on Get error messages

### DIFF
--- a/framework/import.go
+++ b/framework/import.go
@@ -71,14 +71,14 @@ func (m *Import) Get(reqs []*sdk.GetReq) ([]*sdk.GetResult, error) {
 				if !ok {
 					return nil, fmt.Errorf(
 						"key %q doesn't support function calls",
-						strings.Join(req.Keys[:i], "."))
+						strings.Join(req.Keys[:i+1], "."))
 				}
 
 				v, err := m.call(x.Func(k), req.Args)
 				if err != nil {
 					return nil, fmt.Errorf(
 						"error calling function %q: %s",
-						strings.Join(req.Keys[:i], "."), err)
+						strings.Join(req.Keys[:i+1], "."), err)
 				}
 
 				result = v
@@ -92,7 +92,7 @@ func (m *Import) Get(reqs []*sdk.GetReq) ([]*sdk.GetResult, error) {
 				if err != nil {
 					return nil, fmt.Errorf(
 						"error retrieving key %q: %s",
-						strings.Join(req.Keys[:i], "."), err)
+						strings.Join(req.Keys[:i+1], "."), err)
 				}
 
 				result = v


### PR DESCRIPTION
There's currently an off-by-one error on the error reporting with keys.
Example: A get or call error on import.foo.bar("baz") would only report
"foo", and import.foo("bar") would just return a blank string ("").

This corrects that. It also shifts the tests over to allow the
validation of the error message as well, and adds a little bit more
coverage.