### PR TITLE
Add license section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ can be written by implementing the [protocol](https://github.com/hashicorp/senti
 
 To get started writing a Sentinel import, we recommend reading the
 [extending Sentinel](https://docs.hashicorp.com/sentinel/extending/dev) guide.
+
+## License
+
+```
+Copyright 2019 HashiCorp
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+```


### PR DESCRIPTION
This adds a license part to the end of the README.

The MPL default LICENSE file itself contains no template for adding
attribution, hence I usually add it to the bottom of the READMEs for
the projects that I work on.

Adding the license notice is legal in this way as per advice on
Mozilla's site. This is in lieu of headers existing in every file.

References:
MPL license FAQ, Q22: "Does MPL 2.0 require that the MPL 2.0 license
notice header be included in every file?"
  https://www.mozilla.org/en-US/MPL/2.0/FAQ/

Mozilla license headers:
  https://www.mozilla.org/en-US/MPL/headers/