### PR TITLE
framework: ensure null return on deep map get with nil value

### DIFF
--- a/framework/import.go
+++ b/framework/import.go
@@ -93,9 +93,15 @@ func (m *Import) Get(reqs []*sdk.GetReq) ([]*sdk.GetResult, error) {
 
 				result = v
 
-			// For maps with string keys, get the value
+			// For maps with string keys, get the value. If the value is
+			// nil, return sdk.Null to ensure that we don't mess with how
+			// reflection deals with "invalid" zero values in maps. See
+			// Import.reflectMap for more details.
 			case map[string]interface{}:
 				result = x[k.Key]
+				if result == nil {
+					result = sdk.Null
+				}
 
 			// Else...
 			default:

--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -197,6 +197,33 @@ func TestImportGet(t *testing.T) {
 		},
 
 		{
+			"key get map with nil value, full key in get request",
+			&rootEmbedNamespace{&nsKeyValue{
+				Key: "foo",
+				Value: map[string]interface{}{
+					"bar": nil,
+				},
+			}},
+			[]*sdk.GetReq{
+				{
+					Keys: []*sdk.GetKey{
+						{Key: "foo"},
+						{Key: "bar"},
+					},
+					KeyId: 42,
+				},
+			},
+			[]*sdk.GetResult{
+				{
+					Keys:  []string{"foo", "bar"},
+					KeyId: 42,
+					Value: sdk.Null,
+				},
+			},
+			"",
+		},
+
+		{
 			"key get invalid",
 			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
 			[]*sdk.GetReq{


### PR DESCRIPTION
A consequence of the multi-key function call work that has been
added in #23 is that any key past a function call will now be called
after the function call.

Example: json.unmarshal("{\"foo\": null}").foo, which would normally
return the map {"foo": null}, now will fully traverse the map,
returning the underlying null.

Tests that we have for the json import in the core runtime have
revealed an issue in the way we deeply traverse raw maps (not
namespaces) in that if the final value is nil, we treat it as
undefined (like it was the result of a Get call), even though our map
value conversion will convert nils found in map return values to zero
values (so nil for a map[string]interface{}).

This commit fixes that logic so that things function as expected
again.