### PR TITLE
framework: ensure Get for an unknown key on a map returns undefined

### DIFF
--- a/framework/import.go
+++ b/framework/import.go
@@ -143,9 +143,13 @@ func (m *Import) Get(reqs []*sdk.GetReq) ([]*sdk.GetResult, error) {
 			// reflection deals with "invalid" zero values in maps. See
 			// Import.reflectMap for more details.
 			case map[string]interface{}:
-				result = x[k.Key]
-				if result == nil {
-					result = sdk.Null
+				var ok bool
+				if result, ok = x[k.Key]; ok {
+					if result == nil {
+						result = sdk.Null
+					}
+				} else {
+					result = sdk.Undefined
 				}
 
 			// Else...

--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -224,6 +224,31 @@ func TestImportGet(t *testing.T) {
 		},
 
 		{
+			"key get map with unknown key, full key in get request",
+			&rootEmbedNamespace{&nsKeyValue{
+				Key:   "foo",
+				Value: map[string]interface{}{},
+			}},
+			[]*sdk.GetReq{
+				{
+					Keys: []sdk.GetKey{
+						{Key: "foo"},
+						{Key: "bar"},
+					},
+					KeyId: 42,
+				},
+			},
+			[]*sdk.GetResult{
+				{
+					Keys:  []string{"foo", "bar"},
+					KeyId: 42,
+					Value: sdk.Undefined,
+				},
+			},
+			"",
+		},
+
+		{
 			"key get invalid",
 			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
 			[]*sdk.GetReq{


### PR DESCRIPTION
The changes in #25 fixed a problem where (explicit) nulls were
incorrectly being returned as undefined, rather than null. The changes,
however, effectively cut this behavior fully over to null, including the
cases were unknown keys were retrieved.

This fixes it so that unknown keys continue to correctly return
undefined.