### PR TITLE
Go: use Go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.12
+    go: &GOLANG_IMAGE circleci/golang:1.13
   cache:
     go-sum: &GO_SUM_CACHE_KEY go-sum-v1-{{ checksum "go.sum" }}
     sentinel: &SENTINEL_CACHE_KEY sentinel-{{ checksum "Makefile" }}

--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	google.golang.org/grpc v1.18.0
 	gotest.tools/gotestsum v0.3.5
 )
+
+go 1.13


### PR DESCRIPTION
This is for Circle and the directive in go.mod.