### PR TITLE
Circle: fix Sentinel test binary caching for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,10 @@ jobs:
       - restore_cache:
           keys:
             - *GO_SUM_CACHE_KEY
+      - restore_cache:
+          keys:
             - *SENTINEL_CACHE_KEY
-      - run: make /usr/bin/sentinel
+      - run: make /go/bin/sentinel
       - run: make modules
       - run: make tools
       - run: make test-circle
@@ -34,7 +36,7 @@ jobs:
       - save_cache:
           key: *SENTINEL_CACHE_KEY
           paths:
-            - /usr/bin/sentinel
+            - /go/bin/sentinel
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GOTOOLS = \
 	gotest.tools/gotestsum
 
 SENTINEL_VERSION = 0.11.0
+SENTINEL_BIN_PATH := $(shell go env GOPATH)/bin
 
 test: tools
 	gotestsum --format=short-verbose $(TEST) $(TESTARGS)
@@ -21,7 +22,7 @@ test-circle:
 tools:
 	go install $(GOTOOLS)
 
-/usr/bin/sentinel:
+$(SENTINEL_BIN_PATH)/sentinel:
 	gpg --import .circleci/hashicorp.gpg && \
 	cd /tmp && \
 	curl -O https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_linux_amd64.zip && \
@@ -29,7 +30,8 @@ tools:
 	curl -O https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS.sig && \
 	gpg --verify sentinel_${SENTINEL_VERSION}_SHA256SUMS.sig && \
 	shasum --check --ignore-missing sentinel_${SENTINEL_VERSION}_SHA256SUMS && \
-	cd /usr/bin && \
-	sudo unzip /tmp/sentinel_${SENTINEL_VERSION}_linux_amd64.zip
+	cd $(SENTINEL_BIN_PATH) && \
+	unzip /tmp/sentinel_${SENTINEL_VERSION}_linux_amd64.zip && \
+	cd && which sentinel
 
 .PHONY: test generate modules test-circle tools


### PR DESCRIPTION
This fixes the Sentinel test binary caching for Circle.

The current setup was actually completely ineffective as using a
"restore_cache" clause with two keys only restores one key at a time.
This means if there was a go module cache, Sentinel would be skipped.

Additionally, we've observed in other repositories that the Sentinel
cache restore was failing altogether with permission issues. As such,
this also moves the Sentinel binary to a place where it can be restored
with non-root permissions (we use the "go install" binary path here).