### PR TITLE
testing: allow testing for runtime errors

### DIFF
--- a/testing/import_test.go
+++ b/testing/import_test.go
@@ -44,6 +44,15 @@ func TestTestImport(t *testing.T) {
 		})
 	})
 
+	// Test runtime error
+	t.Run("error", func(t *testing.T) {
+		TestImport(&testingiface.RuntimeT{}, TestImportCase{
+			ImportPath: path,
+			Source:     `main = rule { error("nope") }`,
+			Error:      "nope",
+		})
+	})
+
 	// Test configuration
 	t.Run("config", func(t *testing.T) {
 		TestImport(t, TestImportCase{


### PR DESCRIPTION
I realized that it was difficult to write tests for policy functionality we expect to fail, and most tests are happy-path / successful. I could be missing something, but if there's not another way to do this, this seemed like an ok way of allowing testing runtime errors emitted by plugins.