### PR TITLE
rpc: increase the maximum grpc message size

### DIFF
--- a/rpc/import_grpc_client.go
+++ b/rpc/import_grpc_client.go
@@ -2,11 +2,13 @@ package rpc
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/hashicorp/sentinel-sdk"
 	"github.com/hashicorp/sentinel-sdk/encoding"
 	"github.com/hashicorp/sentinel-sdk/proto/go"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 // ImportGRPCClient is a gRPC server for Imports.
@@ -89,9 +91,14 @@ func (m *ImportGRPCClient) Get(rawReqs []*sdk.GetReq) ([]*sdk.GetResult, error) 
 		})
 	}
 
-	resp, err := m.Client.Get(context.Background(), &proto.Get_MultiRequest{
-		Requests: reqs,
-	})
+	resp, err := m.Client.Get(
+		context.Background(),
+		&proto.Get_MultiRequest{
+			Requests: reqs,
+		},
+		grpc.MaxRecvMsgSizeCallOption{MaxRecvMsgSize: math.MaxInt32},
+		grpc.MaxSendMsgSizeCallOption{MaxSendMsgSize: math.MaxInt32},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/serve.go
+++ b/rpc/serve.go
@@ -1,6 +1,10 @@
 package rpc
 
 import (
+	"math"
+
+	"google.golang.org/grpc"
+
 	goplugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/sentinel-sdk"
 )
@@ -43,7 +47,11 @@ func Serve(opts *ServeOpts) {
 	goplugin.Serve(&goplugin.ServeConfig{
 		HandshakeConfig: Handshake,
 		Plugins:         pluginMap(opts),
-		GRPCServer:      goplugin.DefaultGRPCServer,
+		GRPCServer: func(opts []grpc.ServerOption) *grpc.Server {
+			opts = append(opts, grpc.MaxRecvMsgSize(math.MaxInt32))
+			opts = append(opts, grpc.MaxSendMsgSize(math.MaxInt32))
+			return goplugin.DefaultGRPCServer(opts)
+		},
 	})
 }
 


### PR DESCRIPTION
Pass options to the gRPC server so that it will accept large messages. Currently the default gRPC server only allows 4MB. We want to allow plugins to return larger data structures.

This change copies [what Vault does](https://github.com/hashicorp/vault/blob/master/sdk/plugin/serve.go#L73-L74). Terraform also modifies this default. This gives us some assurance that bumping this value up shouldn't cause stability concerns.