### PR TITLE
framework: add test to illustrate non-Map interface passthrough

### DIFF
--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -584,6 +584,38 @@ func TestImportGet(t *testing.T) {
 		},
 
 		{
+			"key get result is a namespace that does not implement map",
+			&rootEmbedNamespace{
+				&nsKeyValue{
+					Key: "foo",
+					Value: &nsKeyValue{
+						Key:   "one",
+						Value: "two",
+					},
+				},
+			},
+			[]*sdk.GetReq{
+				{
+					Keys: []sdk.GetKey{
+						{Key: "foo"},
+					},
+					KeyId: 42,
+				},
+			},
+			[]*sdk.GetResult{
+				{
+					Keys:  []string{"foo"},
+					KeyId: 42,
+					Value: &nsKeyValue{
+						Key:   "one",
+						Value: "two",
+					},
+				},
+			},
+			"",
+		},
+
+		{
 			"key call",
 			&rootEmbedCall{&nsCall{
 				F: func(v string) (interface{}, error) {


### PR DESCRIPTION
This just adds a test to illustrate that a bare framework.Namespace that
does not include framework.Map will be passed through the lower-level
framework.Get method okay, which should make it available for conversion
and subject to the same rules as any other struct.