### PR TITLE
Add helpers for loading TestImportCase structures

### DIFF
--- a/testing/import.go
+++ b/testing/import.go
@@ -79,7 +79,10 @@ type TestImportCase struct {
 //
 // The above would load a TestImport case using the specified options. The
 // config is loaded as a JSON string and unmarshaled into the Config field.
-// The error field is loaded as a string into the Error field.
+// The error field is loaded as a string into the Error field. The 'config'
+// and/or 'error' pragmas *must* be at the very top of the file, starting at
+// line one. When a non-pragma line is encountered, parsing will end and any
+// further comments are disregarded.
 //
 // This makes boilerplate very simple for a large number of Sentinel tests,
 // and allows an entire test to be captured neatly into a single file which

--- a/testing/import.go
+++ b/testing/import.go
@@ -69,9 +69,8 @@ type TestImportCase struct {
 }
 
 // LoadTestImportCase is used to load a TestImportCase from a Sentinel policy
-// file. The policy file is expected to begin with comments in the first
-// line. Certain configuration options are supported in the comment body. The
-// following is a completely valid example:
+// file. Certain test case pragmas are supported in the top-most comment body.
+// The following is a completely valid example:
 //
 //     //config: {"option1": "value1"}
 //     //error: failed to do the thing
@@ -79,10 +78,9 @@ type TestImportCase struct {
 //
 // The above would load a TestImport case using the specified options. The
 // config is loaded as a JSON string and unmarshaled into the Config field.
-// The error field is loaded as a string into the Error field. The 'config'
-// and/or 'error' pragmas *must* be at the very top of the file, starting at
-// line one. When a non-pragma line is encountered, parsing will end and any
-// further comments are disregarded.
+// The error field is loaded as a string into the Error field. Pragmas *must*
+// be at the very top of the file, starting at line one. When a non-pragma
+// line is encountered, parsing will end and any further pragmas are discarded.
 //
 // This makes boilerplate very simple for a large number of Sentinel tests,
 // and allows an entire test to be captured neatly into a single file which
@@ -149,9 +147,10 @@ func LoadTestImportCase(t testing.T, path string) TestImportCase {
 	return tc
 }
 
-// TestDirectory iterates over files in a directory, calls LoadTestImportCase
-// on each file suffixed with ".sentinel", and executes all of the import tests.
-func TestDirectory(t testing.T, path string, customize func(*TestImportCase)) {
+// TestImportDir iterates over files in a directory, calls
+// LoadTestImportCase on each file suffixed with ".sentinel", and executes all
+// of the import tests.
+func TestImportDir(t testing.T, path string, customize func(*TestImportCase)) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		t.Fatal(err)

--- a/testing/import.go
+++ b/testing/import.go
@@ -11,8 +11,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"testing"
 	"text/scanner"
+
+	"github.com/mitchellh/go-testing-interface"
 )
 
 //go:generate go-bindata -nomemcopy -pkg=testing ./data/...
@@ -83,7 +84,7 @@ type TestImportCase struct {
 // This makes boilerplate very simple for a large number of Sentinel tests,
 // and allows an entire test to be captured neatly into a single file which
 // also happens to be the policy being tested.
-func LoadTestImportCase(t *testing.T, path string) TestImportCase {
+func LoadTestImportCase(t testing.T, path string) TestImportCase {
 	fh, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("error opening policy: %v", err)
@@ -145,7 +146,7 @@ func LoadTestImportCase(t *testing.T, path string) TestImportCase {
 	return tc
 }
 
-func TestDirectory(t *testing.T, path string, customize func(*TestImportCase)) {
+func TestDirectory(t testing.T, path string, customize func(*TestImportCase)) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		t.Fatal(err)
@@ -172,9 +173,12 @@ func TestDirectory(t *testing.T, path string, customize func(*TestImportCase)) {
 	}
 
 	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			TestImport(t, tc)
-		})
+		// This would be nice but the interface doesn't have Run() yet.
+		//t.Run(name, func(t testing.T) {
+		//	TestImport(t, tc)
+		//})
+		t.Log(name)
+		TestImport(t, tc)
 	}
 }
 
@@ -192,7 +196,7 @@ func Clean() {
 }
 
 // TestImport tests that a sdk.Import implementation works as expected.
-func TestImport(t *testing.T, c TestImportCase) {
+func TestImport(t testing.T, c TestImportCase) {
 	// Infer the path
 	path, err := ImportPath(c.ImportPath)
 	if err != nil {
@@ -346,7 +350,7 @@ func ImportPath(dir string) (string, error) {
 
 // buildImport compiles the import binary with the given Go import path.
 // The path to the completed binary is inserted into the global importMap.
-func buildImport(t *testing.T, path string) string {
+func buildImport(t testing.T, path string) string {
 	log.Printf("Building binary: %s", path)
 
 	// Create the main.go

--- a/testing/import.go
+++ b/testing/import.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"text/scanner"
 
 	"github.com/mitchellh/go-testing-interface"
 )
@@ -65,6 +66,84 @@ type TestImportCase struct {
 	// Sentinel output is searched for the string given here. If a match is
 	// found, the test passes. If it is not found the test will fail.
 	Error string
+}
+
+// LoadTestImportCase is used to load a TestImportCase from a Sentinel policy
+// file. The policy file is expected to begin with comments in the first
+// line. Certain configuration options are supported in the comment body. The
+// following is a completely valid example:
+//
+//     // config: {"option1": "value1"}
+//     // error: failed to do the thing
+//     main = rule { true }
+//
+// The above would load a TestImport case using the specified options. The
+// config is loaded as a JSON string and unmarshaled into the Config field.
+// The error field is loaded as a string into the Error field.
+//
+// This makes boilerplate very simple for a large number of Sentinel tests,
+// and allows an entire test to be captured neatly into a single file which
+// also happens to be the policy being tested.
+func LoadTestImportCase(t testing.T, path string) TestImportCase {
+	fh, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("error opening policy: %v", err)
+	}
+	defer fh.Close()
+
+	var s scanner.Scanner
+	s.Init(fh)
+	s.Mode ^= scanner.SkipComments
+
+	var errMatch string
+	var configStr string
+
+	for tok := s.Scan(); tok != scanner.EOF; tok = s.Scan() {
+		raw := s.TokenText()
+		content := strings.TrimPrefix(raw, "// ")
+
+		// Make sure we are still in the top comments.
+		if raw == content {
+			break
+		}
+
+		parts := strings.SplitN(content, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		switch parts[0] {
+		case "error":
+			errMatch = strings.TrimSpace(parts[1])
+		case "config":
+			configStr = strings.TrimSpace(parts[1])
+		default:
+			t.Fatalf("unsupported magic comment: %q", parts[0])
+		}
+	}
+
+	if _, err := fh.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	policyBytes, err := ioutil.ReadAll(fh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tc := TestImportCase{
+		Source: string(policyBytes),
+		Error:  errMatch,
+	}
+
+	if configStr != "" {
+		tc.Config = make(map[string]interface{})
+		if err := json.Unmarshal([]byte(configStr), &tc.Config); err != nil {
+			t.Fatalf("error decoding configuration: %v", err)
+		}
+	}
+
+	return tc
 }
 
 // Clean cleans any temporary files created. This should always be called

--- a/testing/import_test.go
+++ b/testing/import_test.go
@@ -94,7 +94,7 @@ func TestTestImport(t *testing.T) {
 
 	// TestDirectory helper
 	t.Run("directory", func(t *testing.T) {
-		TestDirectory(t, "testdata/import-test-dir", func(tc *TestImportCase) {
+		TestImportDir(t, "testdata/import-test-dir", func(tc *TestImportCase) {
 			tc.ImportPath = path
 			tc.Global = map[string]interface{}{"exclamation": "!"}
 		})

--- a/testing/import_test.go
+++ b/testing/import_test.go
@@ -94,7 +94,7 @@ func TestTestImport(t *testing.T) {
 
 	// TestDirectory helper
 	t.Run("directory", func(t *testing.T) {
-		TestDirectory(t, "testdata", func(tc *TestImportCase) {
+		TestDirectory(t, "testdata/import-test-dir", func(tc *TestImportCase) {
 			tc.ImportPath = path
 			tc.Global = map[string]interface{}{"exclamation": "!"}
 		})

--- a/testing/import_test.go
+++ b/testing/import_test.go
@@ -91,4 +91,12 @@ func TestTestImport(t *testing.T) {
 			Source:     `main = foo.bar is "bar!!"`,
 		})
 	})
+
+	// TestDirectory helper
+	t.Run("directory", func(t *testing.T) {
+		TestDirectory(t, "testdata", func(tc *TestImportCase) {
+			tc.ImportPath = path
+			tc.Global = map[string]interface{}{"exclamation": "!"}
+		})
+	})
 }

--- a/testing/testdata/import-test-dir/nope.txt
+++ b/testing/testdata/import-test-dir/nope.txt
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/testing/testdata/import-test-dir/subdir/bad.sentinel
+++ b/testing/testdata/import-test-dir/subdir/bad.sentinel
@@ -1,0 +1,2 @@
+// This policy should not be executed as it is in a subdirectory.
+main = rule { false }

--- a/testing/testdata/import-test-dir/test.sentinel
+++ b/testing/testdata/import-test-dir/test.sentinel
@@ -1,5 +1,5 @@
-// config: {"suffix": " world"}
-// error: hello world!
+//config: {"suffix": " world"}
+//error: hello world!
 
 main = rule {
     error(subject.hello + exclamation)

--- a/testing/testdata/test.sentinel
+++ b/testing/testdata/test.sentinel
@@ -1,0 +1,6 @@
+// config: {"suffix": " world"}
+// error: hello world!
+
+main = rule {
+    error(subject.hello + exclamation)
+}


### PR DESCRIPTION
Adds helper functions to load `TestImportCase` structures from Sentinel policy files using simple pragmas. The idea is to get out of the habit of infinitely adding to our table tests, especially when we start having more complex and multi-line policies. The process of adding a test simply becomes dropping a new policy file into a directory.