### PR TITLE
Add regular expression support to TestImportCase.Error

### DIFF
--- a/testing/import_test.go
+++ b/testing/import_test.go
@@ -53,6 +53,32 @@ func TestTestImport(t *testing.T) {
 		})
 	})
 
+	// Test runtime error w/ regular expression
+	t.Run("error with regex", func(t *testing.T) {
+		TestImport(&testingiface.RuntimeT{}, TestImportCase{
+			ImportPath: path,
+			Source:     `main = rule { error("super 1337 error") }`,
+			Error:      `/super \d+ error/`,
+		})
+	})
+
+	// Test runtime error w/ errored regular expression
+	t.Run("error with errored regex", func(t *testing.T) {
+		// Use a defer to catch a panic that RuntimeT will throw. We can
+		// detect the failure this way.
+		defer func() {
+			if e := recover(); e == nil {
+				t.Fatal("should fail")
+			}
+		}()
+
+		TestImport(&testingiface.RuntimeT{}, TestImportCase{
+			ImportPath: path,
+			Source:     `main = rule { error("super 1337 error") }`,
+			Error:      `/(super \d+ error/`,
+		})
+	})
+
 	// Test configuration
 	t.Run("config", func(t *testing.T) {
 		TestImport(t, TestImportCase{

--- a/testing/testdata/import-test-dir/error-pragma-regex.sentinel
+++ b/testing/testdata/import-test-dir/error-pragma-regex.sentinel
@@ -1,0 +1,5 @@
+//error: /hello \w+!/
+
+main = rule {
+	error("hello world" + exclamation)
+}


### PR DESCRIPTION
This allows an Error string to contain a regular expression to be compiled and matched against the error output. If the Error string is delimited by slashes, it's used as a regular expression. Otherwise, the normal behavior (substring to be contained in the error output) is preserved.

Examples:

```go
// Direct helper API
TestImportCase{Error: `normal substring`}
TestImportCase{Error: "normal substring"}
TestImportCase{Error: `/a \w+ pattern/`}
TestImportCase{Error: "/a \\w+ pattern/"}
```
```
# In a test file, the error pragma:
//error normal substring
//error /a \w+ pattern/
```

Errors in the given error pattern are helpfully surfaced, though this I found to be basically impossible to test because I don't know how to get the output to match on. (It's still tested, but like a similar other test in the suite, it just ensures that _some_ sort of failure occurred) It looks like this:

![image](https://user-images.githubusercontent.com/2430490/68408119-6613c200-014a-11ea-96d7-df38950aed50.png)