### PR TITLE
framework: shorten key path in errors during method chaining

### DIFF
--- a/framework/import.go
+++ b/framework/import.go
@@ -96,6 +96,7 @@ func (m *Import) Get(reqs []*sdk.GetReq) ([]*sdk.GetResult, error) {
 
 		// For each key, perform a get
 		var result interface{} = ns
+		var previousCall = false
 		for i, k := range req.Keys {
 			// If we have arguments at this level, perform a function call.
 			if k.Call() {
@@ -108,14 +109,28 @@ func (m *Import) Get(reqs []*sdk.GetReq) ([]*sdk.GetResult, error) {
 
 				v, err := m.call(x.Func(k.Key), k.Args)
 				if err != nil {
-					return nil, fmt.Errorf(
-						"error calling function %q: %s",
-						strings.Join(req.GetKeys()[:i+1], "."), err)
+					if previousCall {
+						// If the previous key level was a function call, don't
+						// emit the full key path in the error message as it
+						// likely won't make sense.
+						return nil, fmt.Errorf(
+							"error calling function %q: %s", k.Key, err)
+					} else {
+						// The previous key level was a simple value. In this
+						// case it makes sense to emit the full key path.
+						return nil, fmt.Errorf(
+							"error calling function %q: %s",
+							strings.Join(req.GetKeys()[:i+1], "."), err)
+					}
 				}
 
 				result = v
+				previousCall = true
 				continue
 			}
+
+			// Mark that this key level is a non-function.
+			previousCall = false
 
 			switch x := result.(type) {
 			// For namespaces, we get the next value in the chain

--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -1120,7 +1120,7 @@ func TestImportGet(t *testing.T) {
 				},
 			},
 			nil,
-			`error calling function "foo.bar": expected: 2, 3; got: 42, 43`,
+			`error calling function "bar": expected: 2, 3; got: 42, 43`,
 		},
 
 		{

--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -1026,7 +1026,7 @@ func TestImportGet(t *testing.T) {
 				},
 			},
 			nil,
-			`error calling function "foo.bar": foo`,
+			`error calling function "bar": foo`,
 		},
 
 		{


### PR DESCRIPTION
Change the way we present errors from function calls on a namespace to not include the full key path. The key path doesn't seem to add any value to the error messages and instead makes them a little more awkward to parse.

A couple of examples to help understand:

### Policy 1

```
import "http"
main = rule { http.with_timeout(30).get(url) }
```

Before:
```
error calling function "with_timeout.get": expected status code to be one of [200], got 500
```

After:
```
error calling function "get": expected status code to be one of [200], got 500
```

### Policy 2

```
import "time"
main = rule { time.load(123).before("nope") }
```

Before (also lol at the randomness of this error):
```
error calling function "load.before": parsing time "nope" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "nope" as "2006"
```

After:
```
error calling function "before": parsing time "nope" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "nope" as "2006"
```

I had originally added some code to differentiate between method call chaining and accessing fields of a namespace via `Get()`, such that we would preserve the extra context in cases where you are calling a method off of a key (like `time.now.before()`). However, this still made little sense and added nothing to the errors (you can imagine the above producing `error calling method now.before`).