### PR TITLE
framework: handle nils in slices

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -177,6 +177,13 @@ var encodingTests = []struct {
 		true,
 	},
 
+	{
+		"slice with null value",
+		[]interface{}{nil},
+		[]interface{}{sdk.Null},
+		false,
+	},
+
 	//-----------------------------------------------------------
 	// Bool
 

--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -197,6 +197,30 @@ func TestImportGet(t *testing.T) {
 		},
 
 		{
+			"key get slice with nil value",
+			&rootEmbedNamespace{&nsKeyValue{
+				Key:   "foo",
+				Value: []interface{}{nil},
+			}},
+			[]*sdk.GetReq{
+				{
+					Keys: []sdk.GetKey{
+						{Key: "foo"},
+					},
+					KeyId: 42,
+				},
+			},
+			[]*sdk.GetResult{
+				{
+					Keys:  []string{"foo"},
+					KeyId: 42,
+					Value: []interface{}{nil},
+				},
+			},
+			"",
+		},
+
+		{
 			"key get map with nil value, full key in get request",
 			&rootEmbedNamespace{&nsKeyValue{
 				Key: "foo",

--- a/framework/reflect.go
+++ b/framework/reflect.go
@@ -99,6 +99,12 @@ func (m *Import) reflectSlice(v reflect.Value) (reflect.Value, error) {
 			return v, err
 		}
 
+		// If the value isn't valid, we set the value of the element to
+		// the zero value for the proper type.
+		if !newElem.IsValid() {
+			newElem = reflect.Zero(v.Type().Elem())
+		}
+
 		elem.Set(newElem)
 	}
 


### PR DESCRIPTION
This fixes an issue with the post-Get value handler and slices/lists
with null elements, handling them in a fashion similar to how maps
handle these values (added in 9f5e918e).