### PR TITLE
framework: ensure result reflection is thread safe and immutable

### DIFF
--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -4,13 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kr/pretty"
 
-	"github.com/hashicorp/sentinel-sdk"
+	sdk "github.com/hashicorp/sentinel-sdk"
 )
 
 func TestImport_impl(t *testing.T) {
@@ -87,1196 +88,1193 @@ func (r *rootNamespaceCreator) Namespace() Namespace                   { return 
 //-------------------------------------------------------------------
 // Get
 
-func TestImportGet(t *testing.T) {
-	// Used a lot
-	undefined := sdk.Undefined
-
-	cases := []struct {
-		Name        string
-		Root        Root
-		Req         []*sdk.GetReq
-		Resp        []*sdk.GetResult
-		ExpectedErr string
-	}{
-		{
-			"key get",
-			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
+var getCases = []struct {
+	Name        string
+	Root        Root
+	Req         []*sdk.GetReq
+	Resp        []*sdk.GetResult
+	ExpectedErr string
+}{
+	{
+		"key get",
+		&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
 				},
+				KeyId: 42,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: "bar",
-				},
-			},
-			"",
 		},
-
-		{
-			"key get nil",
-			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: nil}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: "bar",
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: undefined,
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get map",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
+	{
+		"key get nil",
+		&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: nil}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: sdk.Undefined,
+			},
+		},
+		"",
+	},
+
+	{
+		"key get map",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]interface{}{
+				"bar": 42,
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
 				Value: map[string]interface{}{
 					"bar": 42,
 				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: map[string]interface{}{
-						"bar": 42,
-					},
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get map with nil value",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
+	{
+		"key get map with nil value",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]interface{}{
+				"bar": nil,
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
 				Value: map[string]interface{}{
 					"bar": nil,
 				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: map[string]interface{}{
-						"bar": nil,
-					},
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get slice with nil value",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key:   "foo",
+	{
+		"key get slice with nil value",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key:   "foo",
+			Value: []interface{}{nil},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
 				Value: []interface{}{nil},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: []interface{}{nil},
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get map with nil value, full key in get request",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: map[string]interface{}{
-					"bar": nil,
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "bar"},
-					},
-					KeyId: 42,
-				},
+	{
+		"key get map with nil value, full key in get request",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]interface{}{
+				"bar": nil,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "bar"},
-					KeyId: 42,
-					Value: sdk.Null,
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "bar"},
 				},
+				KeyId: 42,
 			},
-			"",
 		},
-
-		{
-			"key get map with unknown key, full key in get request",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key:   "foo",
-				Value: map[string]interface{}{},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "bar"},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "bar"},
+				KeyId: 42,
+				Value: sdk.Null,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "bar"},
-					KeyId: 42,
-					Value: sdk.Undefined,
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get invalid",
-			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "unknown"},
-					},
-					KeyId: 42,
+	{
+		"key get map with unknown key, full key in get request",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key:   "foo",
+			Value: map[string]interface{}{},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "bar"},
 				},
+				KeyId: 42,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"unknown"},
-					KeyId: 42,
-					Value: undefined,
-				},
-			},
-			"",
 		},
-
-		{
-			"key get nested",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: &nsKeyValue{
-					Key:   "child",
-					Value: "bar",
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "child"},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "bar"},
+				KeyId: 42,
+				Value: sdk.Undefined,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "child"},
-					KeyId: 42,
-					Value: "bar",
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get map value",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: map[string]interface{}{
-					"child": "bar",
+	{
+		"key get invalid",
+		&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "unknown"},
 				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "child"},
-					},
-					KeyId: 42,
-				},
+				KeyId: 42,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "child"},
-					KeyId: 42,
-					Value: "bar",
-				},
-			},
-			"",
 		},
-
-		{
-			"key get map value with specific type",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: map[string]int64{
-					"child": 84,
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "child"},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"unknown"},
+				KeyId: 42,
+				Value: sdk.Undefined,
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "child"},
-					KeyId: 42,
-					Value: int64(84),
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get missing map value with specific type",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: map[string]int64{
-					"child": 84,
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "nope"},
-					},
-					KeyId: 42,
-				},
+	{
+		"key get nested",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: &nsKeyValue{
+				Key:   "child",
+				Value: "bar",
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "nope"},
-					KeyId: 42,
-					Value: undefined,
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "child"},
 				},
+				KeyId: 42,
 			},
-			"",
 		},
-
-		{
-			"key get map value that is a namespace",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: map[string]interface{}{
-					"child": &nsKeyValueMap{
-						Value: map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "child"},
+				KeyId: 42,
+				Value: "bar",
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
+		},
+		"",
+	},
+
+	{
+		"key get map value",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]interface{}{
+				"child": "bar",
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "child"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "child"},
+				KeyId: 42,
+				Value: "bar",
+			},
+		},
+		"",
+	},
+
+	{
+		"key get map value with specific type",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]int64{
+				"child": 84,
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "child"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "child"},
+				KeyId: 42,
+				Value: int64(84),
+			},
+		},
+		"",
+	},
+
+	{
+		"key get missing map value with specific type",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]int64{
+				"child": 84,
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "nope"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "nope"},
+				KeyId: 42,
+				Value: sdk.Undefined,
+			},
+		},
+		"",
+	},
+
+	{
+		"key get map value that is a namespace",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]interface{}{
+				"child": &nsKeyValueMap{
 					Value: map[string]interface{}{
-						"child": map[string]interface{}{
-							"foo": "bar",
-						},
+						"foo": "bar",
 					},
 				},
 			},
-			"",
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
 		},
-
-		{
-			"key get map value that is a namespace (two levels)",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
 				Value: map[string]interface{}{
-					"child": &nsKeyValueMap{
-						Value: map[string]interface{}{
-							"foo": &nsKeyValueMap{
-								Value: map[string]interface{}{
-									"bar": "baz",
-								},
-							},
-						},
+					"child": map[string]interface{}{
+						"foo": "bar",
 					},
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
 				},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
+		},
+		"",
+	},
+
+	{
+		"key get map value that is a namespace (two levels)",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[string]interface{}{
+				"child": &nsKeyValueMap{
 					Value: map[string]interface{}{
-						"child": map[string]interface{}{
-							"foo": map[string]interface{}{
+						"foo": &nsKeyValueMap{
+							Value: map[string]interface{}{
 								"bar": "baz",
 							},
 						},
 					},
 				},
 			},
-			"",
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
 		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: map[string]interface{}{
+					"child": map[string]interface{}{
+						"foo": map[string]interface{}{
+							"bar": "baz",
+						},
+					},
+				},
+			},
+		},
+		"",
+	},
 
-		{
-			"key get slice value that is a namespace",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
+	{
+		"key get slice value that is a namespace",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: []interface{}{
+				&nsKeyValueMap{
+					Value: map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
 				Value: []interface{}{
-					&nsKeyValueMap{
-						Value: map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: []interface{}{
-						map[string]interface{}{
-							"foo": "bar",
-						},
+					map[string]interface{}{
+						"foo": "bar",
 					},
 				},
 			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get nested invalid",
-			&rootEmbedNamespace{&nsKeyValue{
+	{
+		"key get nested invalid",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: &nsKeyValue{
+				Key:   "child",
+				Value: "bar",
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "unknown"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "unknown"},
+				KeyId: 42,
+				Value: sdk.Undefined,
+			},
+		},
+		"",
+	},
+
+	{
+		"key get multiple",
+		&rootEmbedNamespace{&nsKeyValueMap{
+			Value: map[string]interface{}{
+				"foo": "foovalue",
+				"bar": "barvalue",
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 1,
+			},
+			{
+				Keys: []sdk.GetKey{
+					{Key: "bar"},
+				},
+				KeyId: 3,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 1,
+				Value: "foovalue",
+			},
+			{
+				Keys:  []string{"bar"},
+				KeyId: 3,
+				Value: "barvalue",
+			},
+		},
+		"",
+	},
+
+	{
+		"key get map",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: &nsKeyValueMap{
+				Value: map[string]interface{}{
+					"key":     "value",
+					"another": "value",
+				},
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: map[string]interface{}{
+					"key":     "value",
+					"another": "value",
+				},
+			},
+		},
+		"",
+	},
+
+	{
+		"key get result is a namespace that does not implement map",
+		&rootEmbedNamespace{
+			&nsKeyValue{
 				Key: "foo",
 				Value: &nsKeyValue{
-					Key:   "child",
-					Value: "bar",
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "unknown"},
-					},
-					KeyId: 42,
+					Key:   "one",
+					Value: "two",
 				},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "unknown"},
-					KeyId: 42,
-					Value: undefined,
-				},
-			},
-			"",
 		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: &nsKeyValue{
+					Key:   "one",
+					Value: "two",
+				},
+			},
+		},
+		"",
+	},
 
-		{
-			"key get multiple",
-			&rootEmbedNamespace{&nsKeyValueMap{
+	{
+		"key call",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				return v, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"asdf"}},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: "asdf",
+			},
+		},
+		"",
+	},
+
+	{
+		"key call with invalid but convertable type",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				return v, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{42}},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: "42",
+			},
+		},
+		"",
+	},
+
+	{
+		"key call with namespace return",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				return &nsKeyValueMap{Value: map[string]interface{}{v: "bar"}}, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"asdf"}},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
 				Value: map[string]interface{}{
-					"foo": "foovalue",
-					"bar": "barvalue",
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 1,
-				},
-				{
-					Keys: []sdk.GetKey{
-						{Key: "bar"},
-					},
-					KeyId: 3,
+					"asdf": "bar",
 				},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 1,
-					Value: "foovalue",
-				},
-				{
-					Keys:  []string{"bar"},
-					KeyId: 3,
-					Value: "barvalue",
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key get map",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: &nsKeyValueMap{
-					Value: map[string]interface{}{
-						"key":     "value",
-						"another": "value",
-					},
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
+	{
+		"key call with no error result",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) interface{} {
+				return v
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: map[string]interface{}{
-						"key":     "value",
-						"another": "value",
-					},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"asdf"}},
 				},
+				KeyId: 42,
 			},
-			"",
 		},
-
-		{
-			"key get result is a namespace that does not implement map",
-			&rootEmbedNamespace{
-				&nsKeyValue{
-					Key: "foo",
-					Value: &nsKeyValue{
-						Key:   "one",
-						Value: "two",
-					},
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: "asdf",
 			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: &nsKeyValue{
-						Key:   "one",
-						Value: "two",
-					},
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key call",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					return v, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"asdf"}},
+	{
+		"multiple levels, multiple calls",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				if v != "one" {
+					return nil, fmt.Errorf("expected \"one\", got %q", v)
+				}
+
+				return &nsCall{
+					F: func(a, b int) (interface{}, error) {
+						if a != 2 && b != 3 {
+							return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
+						}
+
+						return "baz", nil
 					},
-					KeyId: 42,
-				},
+				}, nil
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: "asdf",
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"one"}},
+					{Key: "bar", Args: []interface{}{2, 3}},
 				},
+				KeyId: 42,
 			},
-			"",
 		},
-
-		{
-			"key call with invalid but convertable type",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					return v, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{42}},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "bar"},
+				KeyId: 42,
+				Value: "baz",
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: "42",
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"key call with namespace return",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					return &nsKeyValueMap{Value: map[string]interface{}{v: "bar"}}, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"asdf"}},
-					},
-					KeyId: 42,
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: map[string]interface{}{
-						"asdf": "bar",
-					},
-				},
-			},
-			"",
-		},
+	{
+		"call, get, call",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				if v != "one" {
+					return nil, fmt.Errorf("expected \"one\", got %q", v)
+				}
 
-		{
-			"key call with no error result",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) interface{} {
-					return v
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"asdf"}},
-					},
-					KeyId: 42,
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: "asdf",
-				},
-			},
-			"",
-		},
-
-		{
-			"multiple levels, multiple calls",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					if v != "one" {
-						return nil, fmt.Errorf("expected \"one\", got %q", v)
-					}
-
-					return &nsCall{
+				return &nsKeyValue{
+					Key: "bar",
+					Value: &nsCall{
 						F: func(a, b int) (interface{}, error) {
 							if a != 2 && b != 3 {
 								return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
 							}
 
-							return "baz", nil
+							return "qux", nil
 						},
-					}, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"one"}},
-						{Key: "bar", Args: []interface{}{2, 3}},
 					},
-					KeyId: 42,
-				},
+				}, nil
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "bar"},
-					KeyId: 42,
-					Value: "baz",
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"one"}},
+					{Key: "bar"},
+					{Key: "baz", Args: []interface{}{2, 3}},
 				},
+				KeyId: 42,
 			},
-			"",
 		},
-
-		{
-			"call, get, call",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					if v != "one" {
-						return nil, fmt.Errorf("expected \"one\", got %q", v)
-					}
-
-					return &nsKeyValue{
-						Key: "bar",
-						Value: &nsCall{
-							F: func(a, b int) (interface{}, error) {
-								if a != 2 && b != 3 {
-									return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
-								}
-
-								return "qux", nil
-							},
-						},
-					}, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"one"}},
-						{Key: "bar"},
-						{Key: "baz", Args: []interface{}{2, 3}},
-					},
-					KeyId: 42,
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo", "bar", "baz"},
+				KeyId: 42,
+				Value: "qux",
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo", "bar", "baz"},
-					KeyId: 42,
-					Value: "qux",
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"get call with receiver",
-			&rootNew{},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
+	{
+		"get call with receiver",
+		&rootNew{},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
 				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
 			},
-			[]*sdk.GetResult{
-				{
-					Keys:     []string{"foo"},
-					KeyId:    42,
-					Value:    map[string]interface{}{"result": "New called"},
-					Context:  map[string]interface{}{"foo": map[string]interface{}{"result": "New called"}},
-					Callable: true,
-				},
-			},
-			"",
 		},
-
-		{
-			"get call with receiver (assert input)",
-			&rootNew{
-				F: func(data map[string]interface{}) (Namespace, error) {
-					if data["a"] == "b" {
-						return &nsKeyValueMap{map[string]interface{}{
-							"foo": map[string]interface{}{
-								"result": "OK",
-							},
-						}}, nil
-					}
-
-					return nil, nil
-				},
+		[]*sdk.GetResult{
+			{
+				Keys:     []string{"foo"},
+				KeyId:    42,
+				Value:    map[string]interface{}{"result": "New called"},
+				Context:  map[string]interface{}{"foo": map[string]interface{}{"result": "New called"}},
+				Callable: true,
 			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:     []string{"foo"},
-					KeyId:    42,
-					Value:    map[string]interface{}{"result": "OK"},
-					Context:  map[string]interface{}{"foo": map[string]interface{}{"result": "OK"}},
-					Callable: true,
-				},
-			},
-			"",
 		},
+		"",
+	},
 
-		{
-			"func call with receiver (non-callable result, mutate receiver)",
-			&rootNew{
-				F: func(data map[string]interface{}) (Namespace, error) {
-					return &nsMutable{Value: data["value"].(string)}, nil
-				},
-			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"two"}},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"value": "one"},
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:    []string{"foo"},
-					KeyId:   42,
-					Value:   "OK",
-					Context: map[string]interface{}{"value": "two"},
-				},
-			},
-			"",
-		},
-
-		{
-			"get without receiver on New implementation",
-			&rootNew{},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:     []string{"foo"},
-					KeyId:    42,
-					Value:    map[string]interface{}{"result": "New not called (Get)"},
-					Callable: true,
-				},
-			},
-			"",
-		},
-
-		{
-			"func call without receiver on New implementation",
-			&rootNew{},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{}},
-					},
-					KeyId: 42,
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:     []string{"foo"},
-					KeyId:    42,
-					Value:    map[string]interface{}{"result": "New not called (Func)"},
-					Callable: true,
-				},
-			},
-			"",
-		},
-
-		{
-			"unknown receiver data from instantiation",
-			&rootNew{
-				F: func(map[string]interface{}) (Namespace, error) {
-					return nil, nil
-				},
-			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			[]*sdk.GetResult{
-				{
-					Keys:  []string{"foo"},
-					KeyId: 42,
-					Value: sdk.Undefined,
-				},
-			},
-			"",
-		},
-
-		{
-			"key call unsupported",
-			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"asdf"}},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`key "foo" doesn't support function calls`,
-		},
-
-		{
-			"key call with too few arguments",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					return v, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{}},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`error calling function "foo": expected 1 arguments, got 0`,
-		},
-
-		{
-			"key call with too many arguments",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					return v, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{1, 2}},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`error calling function "foo": expected 1 arguments, got 2`,
-		},
-
-		{
-			"multi-level key call error message",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key: "foo",
-				Value: &nsCall{
-					F: func() (interface{}, error) {
-						return "", fmt.Errorf("foo")
-					},
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "bar", Args: []interface{}{}},
-					},
-				},
-			},
-			nil,
-			`error calling function "bar": foo`,
-		},
-
-		{
-			"bad get",
-			&rootEmbedNamespace{&nsGetErr{}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`error retrieving key "foo": get error`,
-		},
-
-		{
-			"bad map",
-			&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: &nsMapErr{}}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`error retrieving key "foo": map error`,
-		},
-
-		{
-			"multi-call, error in outer",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					if v != "one" {
-						return nil, fmt.Errorf("expected \"one\", got %q", v)
-					}
-
-					return &nsCall{
-						F: func(a, b int) (interface{}, error) {
-							if a != 2 && b != 3 {
-								return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
-							}
-
-							return "baz", nil
-						},
-					}, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"bad"}},
-						{Key: "bar", Args: []interface{}{2, 3}},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`error calling function "foo": expected "one", got "bad"`,
-		},
-
-		{
-			"multi-call, error in inner",
-			&rootEmbedCall{&nsCall{
-				F: func(v string) (interface{}, error) {
-					if v != "one" {
-						return nil, fmt.Errorf("expected \"one\", got %q", v)
-					}
-
-					return &nsCall{
-						F: func(a, b int) (interface{}, error) {
-							if a != 2 && b != 3 {
-								return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
-							}
-
-							return "baz", nil
-						},
-					}, nil
-				},
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo", Args: []interface{}{"one"}},
-						{Key: "bar", Args: []interface{}{42, 43}},
-					},
-					KeyId: 42,
-				},
-			},
-			nil,
-			`error calling function "bar": expected: 2, 3; got: 42, 43`,
-		},
-
-		{
-			"error from receiver constructor",
-			&rootNew{
-				F: func(map[string]interface{}) (Namespace, error) {
-					return nil, fmt.Errorf("OK")
-				},
-			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			nil,
-			"error instantiating namespace: OK",
-		},
-
-		{
-			"error from receiver constructor, function call",
-			&rootNew{
-				F: func(map[string]interface{}) (Namespace, error) {
-					return nil, nil
-				},
-			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-						{Key: "bar", Args: []interface{}{"one"}},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			nil,
-			`attempting to call function "foo.bar" on undefined receiver`,
-		},
-
-		{
-			"Context supplied but New not implemented",
-			&rootEmbedNamespace{&nsKeyValue{
-				Key:   "foo",
-				Value: "bar",
-			}},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			nil,
-			"sdk.GetReq.Context present but import does not support framework.New",
-		},
-
-		{
-			"receiver marshal error",
-			&rootNew{
-				F: func(data map[string]interface{}) (Namespace, error) {
+	{
+		"get call with receiver (assert input)",
+		&rootNew{
+			F: func(data map[string]interface{}) (Namespace, error) {
+				if data["a"] == "b" {
 					return &nsKeyValueMap{map[string]interface{}{
 						"foo": map[string]interface{}{
-							"result": "Not OK",
+							"result": "OK",
 						},
-						"bar": &nsMapErr{},
 					}}, nil
-				},
-			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			nil,
-			`error marshaling receiver after retrieving key "foo": map error`,
-		},
+				}
 
-		{
-			"receiver non-object",
-			&rootNew{
-				F: func(data map[string]interface{}) (Namespace, error) {
-					return &nsKeyValue{
-						Key:   "foo",
-						Value: "Not OK",
-					}, nil
-				},
+				return nil, nil
 			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			nil,
-			`error marshaling receiver after retrieving key "foo": receiver is no longer an object`,
 		},
-
-		{
-			"receiver nil object",
-			&rootNew{
-				F: func(data map[string]interface{}) (Namespace, error) {
-					return &nsNilable{}, nil
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
 				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
 			},
-			[]*sdk.GetReq{
-				{
-					Keys: []sdk.GetKey{
-						{Key: "foo"},
-					},
-					KeyId:   42,
-					Context: map[string]interface{}{"a": "b"},
-				},
-			},
-			nil,
-			`error marshaling receiver after retrieving key "foo": receiver is now nil`,
 		},
-	}
+		[]*sdk.GetResult{
+			{
+				Keys:     []string{"foo"},
+				KeyId:    42,
+				Value:    map[string]interface{}{"result": "OK"},
+				Context:  map[string]interface{}{"foo": map[string]interface{}{"result": "OK"}},
+				Callable: true,
+			},
+		},
+		"",
+	},
 
-	for _, tc := range cases {
+	{
+		"func call with receiver (non-callable result, mutate receiver)",
+		&rootNew{
+			F: func(data map[string]interface{}) (Namespace, error) {
+				return &nsMutable{Value: data["value"].(string)}, nil
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"two"}},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"value": "one"},
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:    []string{"foo"},
+				KeyId:   42,
+				Value:   "OK",
+				Context: map[string]interface{}{"value": "two"},
+			},
+		},
+		"",
+	},
+
+	{
+		"get without receiver on New implementation",
+		&rootNew{},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:     []string{"foo"},
+				KeyId:    42,
+				Value:    map[string]interface{}{"result": "New not called (Get)"},
+				Callable: true,
+			},
+		},
+		"",
+	},
+
+	{
+		"func call without receiver on New implementation",
+		&rootNew{},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{}},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:     []string{"foo"},
+				KeyId:    42,
+				Value:    map[string]interface{}{"result": "New not called (Func)"},
+				Callable: true,
+			},
+		},
+		"",
+	},
+
+	{
+		"unknown receiver data from instantiation",
+		&rootNew{
+			F: func(map[string]interface{}) (Namespace, error) {
+				return nil, nil
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: sdk.Undefined,
+			},
+		},
+		"",
+	},
+
+	{
+		"key call unsupported",
+		&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: "bar"}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"asdf"}},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`key "foo" doesn't support function calls`,
+	},
+
+	{
+		"key call with too few arguments",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				return v, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{}},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`error calling function "foo": expected 1 arguments, got 0`,
+	},
+
+	{
+		"key call with too many arguments",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				return v, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{1, 2}},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`error calling function "foo": expected 1 arguments, got 2`,
+	},
+
+	{
+		"multi-level key call error message",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: &nsCall{
+				F: func() (interface{}, error) {
+					return "", fmt.Errorf("foo")
+				},
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "bar", Args: []interface{}{}},
+				},
+			},
+		},
+		nil,
+		`error calling function "bar": foo`,
+	},
+
+	{
+		"bad get",
+		&rootEmbedNamespace{&nsGetErr{}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`error retrieving key "foo": get error`,
+	},
+
+	{
+		"bad map",
+		&rootEmbedNamespace{&nsKeyValue{Key: "foo", Value: &nsMapErr{}}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`error retrieving key "foo": map error`,
+	},
+
+	{
+		"multi-call, error in outer",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				if v != "one" {
+					return nil, fmt.Errorf("expected \"one\", got %q", v)
+				}
+
+				return &nsCall{
+					F: func(a, b int) (interface{}, error) {
+						if a != 2 && b != 3 {
+							return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
+						}
+
+						return "baz", nil
+					},
+				}, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"bad"}},
+					{Key: "bar", Args: []interface{}{2, 3}},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`error calling function "foo": expected "one", got "bad"`,
+	},
+
+	{
+		"multi-call, error in inner",
+		&rootEmbedCall{&nsCall{
+			F: func(v string) (interface{}, error) {
+				if v != "one" {
+					return nil, fmt.Errorf("expected \"one\", got %q", v)
+				}
+
+				return &nsCall{
+					F: func(a, b int) (interface{}, error) {
+						if a != 2 && b != 3 {
+							return nil, fmt.Errorf("expected: 2, 3; got: %d, %d", a, b)
+						}
+
+						return "baz", nil
+					},
+				}, nil
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo", Args: []interface{}{"one"}},
+					{Key: "bar", Args: []interface{}{42, 43}},
+				},
+				KeyId: 42,
+			},
+		},
+		nil,
+		`error calling function "bar": expected: 2, 3; got: 42, 43`,
+	},
+
+	{
+		"error from receiver constructor",
+		&rootNew{
+			F: func(map[string]interface{}) (Namespace, error) {
+				return nil, fmt.Errorf("OK")
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		nil,
+		"error instantiating namespace: OK",
+	},
+
+	{
+		"error from receiver constructor, function call",
+		&rootNew{
+			F: func(map[string]interface{}) (Namespace, error) {
+				return nil, nil
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+					{Key: "bar", Args: []interface{}{"one"}},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		nil,
+		`attempting to call function "foo.bar" on undefined receiver`,
+	},
+
+	{
+		"Context supplied but New not implemented",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key:   "foo",
+			Value: "bar",
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		nil,
+		"sdk.GetReq.Context present but import does not support framework.New",
+	},
+
+	{
+		"receiver marshal error",
+		&rootNew{
+			F: func(data map[string]interface{}) (Namespace, error) {
+				return &nsKeyValueMap{map[string]interface{}{
+					"foo": map[string]interface{}{
+						"result": "Not OK",
+					},
+					"bar": &nsMapErr{},
+				}}, nil
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		nil,
+		`error marshaling receiver after retrieving key "foo": map error`,
+	},
+
+	{
+		"receiver non-object",
+		&rootNew{
+			F: func(data map[string]interface{}) (Namespace, error) {
+				return &nsKeyValue{
+					Key:   "foo",
+					Value: "Not OK",
+				}, nil
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		nil,
+		`error marshaling receiver after retrieving key "foo": receiver is no longer an object`,
+	},
+
+	{
+		"receiver nil object",
+		&rootNew{
+			F: func(data map[string]interface{}) (Namespace, error) {
+				return &nsNilable{}, nil
+			},
+		},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId:   42,
+				Context: map[string]interface{}{"a": "b"},
+			},
+		},
+		nil,
+		`error marshaling receiver after retrieving key "foo": receiver is now nil`,
+	},
+}
+
+func TestImportGet(t *testing.T) {
+	for _, tc := range getCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			impt := &Import{
 				Root: tc.Root,
@@ -1305,6 +1303,117 @@ func TestImportGet(t *testing.T) {
 				t.Fatalf("bad: %s", pretty.Sprint(actual))
 			}
 		})
+	}
+}
+
+func TestImportGetConcurrent(t *testing.T) {
+	for _, tc := range getCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			impt := &Import{
+				Root: tc.Root,
+			}
+
+			// Configure
+			err := impt.Configure(map[string]interface{}{})
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			// Perform the reqs, in parallel, 1000x
+			var wg sync.WaitGroup
+			runErr := make(chan error, 1000)
+			actuals := make(chan []*sdk.GetResult, 1000)
+			for i := 0; i < 1000; i++ {
+				wg.Add(1)
+				go func() {
+					actual, err := impt.Get(tc.Req)
+					if err != nil {
+						if tc.ExpectedErr != "" {
+							if err.Error() != tc.ExpectedErr {
+								runErr <- fmt.Errorf("expected error to be %q, got %q", tc.ExpectedErr, err.Error())
+							}
+						} else {
+							runErr <- fmt.Errorf("err: %s", err)
+						}
+
+						return
+					}
+
+					actuals <- actual
+				}()
+
+				wg.Done()
+			}
+
+			wg.Wait()
+
+			nErrs := len(runErr)
+			if nErrs > 0 {
+				t.Fatalf("%d errors, first error: %s", nErrs, <-runErr)
+			}
+
+			for len(actuals) > 0 {
+				actual := <-actuals
+				if !reflect.DeepEqual(actual, tc.Resp) {
+					t.Fatalf("bad response encountered: %s", pretty.Sprint(actual))
+				}
+			}
+		})
+	}
+}
+
+// TestImportGetImmutable checks to ensure that any deep response
+// reflection we do does not alter the structure of the original
+// underlying import data.
+func TestImportGetImmutable(t *testing.T) {
+	imptF := func() *Import {
+		return &Import{
+			Root: &rootEmbedNamespace{&nsKeyValue{
+				Key: "foo",
+				Value: &nsKeyValueMap{
+					Value: map[string]interface{}{
+						"key":     "value",
+						"another": "value",
+						"embedded_map": &nsKeyValueMap{
+							Value: map[string]interface{}{
+								"key": "value",
+							},
+						},
+						"embedded_slice": []*nsKeyValueMap{
+							{
+								Value: map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+				},
+			}},
+		}
+	}
+
+	actual := imptF()
+	expected := imptF()
+
+	err := actual.Configure(map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = actual.Get([]*sdk.GetReq{
+		{
+			Keys: []sdk.GetKey{
+				{Key: "foo"},
+			},
+			KeyId: 42,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatal("import data should not have been altered")
 	}
 }
 


### PR DESCRIPTION
Concurrency scenarios that involve deep reflection of import namespaces
with deep maps and slices can create problems during reflection of a Get
result that ultimately create two problems:

* Concurrent modification of a map, or concurrent iteration *and*
modification of a map. We do not perform any locking on this data, and,
given that the result should be read-only at this point, there should
not need to be.

* The above alludes to the fact that the current result reflection is
actually modifying the result value in-place when it comes to maps and
slices. This method is assuming that the data in the result is actually
a copy of any underlying import data, which is actually not the case -
in addition to the nuances of Go map and slice internals, the return
data could contain direct pointers to namespaces or other internal
structures that would not be expecting to be altered by a process
working on the *result* of a call.

This updates the internal reflectMap and reflectSlice methods to ensure
that results of data transformation are being written to new maps and
slices, instead of the existing ones. This corrects both issues - map
writes are no longer happening concurrently to the same map, and
original values are not being modified.