### PR TITLE
framework: ensure new map copy logic works for non-string keys

### DIFF
--- a/framework/import_test.go
+++ b/framework/import_test.go
@@ -166,6 +166,34 @@ var getCases = []struct {
 	},
 
 	{
+		"key get map with int key",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: map[int]interface{}{
+				42: "bar",
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: map[int]interface{}{
+					42: "bar",
+				},
+			},
+		},
+		"",
+	},
+
+	{
 		"key get map with nil value",
 		&rootEmbedNamespace{&nsKeyValue{
 			Key: "foo",


### PR DESCRIPTION
Issue #45 incorrectly assumed all maps coming from return data would be
string-keyed. This is not the case.

This fixes things to allow for non-string-keyed values to be returned.
We still use a hard interface{} as the value type.