### PR TITLE
Ensure values of maps that are empty maps are string keyed

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/sentinel-sdk"
+	sdk "github.com/hashicorp/sentinel-sdk"
 )
 
 func TestEncoding(t *testing.T) {
@@ -125,6 +125,17 @@ var encodingTests = []struct {
 		},
 		map[string]interface{}{
 			"foo": sdk.Null,
+		},
+		false,
+	},
+
+	{
+		"map with empty map",
+		map[string]interface{}{
+			"foo": map[interface{}]interface{}{},
+		},
+		map[string]interface{}{
+			"foo": map[string]interface{}{},
 		},
 		false,
 	},

--- a/encoding/value_to_go.go
+++ b/encoding/value_to_go.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/hashicorp/sentinel-sdk"
-	"github.com/hashicorp/sentinel-sdk/proto/go"
+	sdk "github.com/hashicorp/sentinel-sdk"
+	proto "github.com/hashicorp/sentinel-sdk/proto/go"
 )
 
 var (
@@ -247,6 +247,14 @@ func convertValueMap(raw *proto.Value, t reflect.Type) (interface{}, error) {
 	m := raw.Value.(*proto.Value_ValueMap).ValueMap
 	keyTyp := t.Key()
 	elemTyp := t.Elem()
+	if len(m.Elems) == 0 {
+		// as we have no elements, it is much safer to presume a key type of
+		// string to ensure safety when attempting to perform actions such
+		// as json marshalling
+		mapType := reflect.MapOf(reflect.TypeOf(""), elemTyp)
+		return reflect.MakeMap(mapType).Interface(), nil
+	}
+
 	mapVal := reflect.MakeMap(t)
 	for _, elt := range m.Elems {
 		// Convert the key


### PR DESCRIPTION
There is an issue within the `json` import where empty map values cannot be passed at any level into the `marshal` method. This fixes this issue by translating any empty map value into `map[string]interface{}`. Although it could be argued that assuming a key type of `string` is a strange assumption, there should not be any side effects due to it's inherent emptiness.