### PR TITLE
Use .exe extension on built imports

### DIFF
--- a/testing/import.go
+++ b/testing/import.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"text/scanner"
 
@@ -414,8 +415,14 @@ func buildImport(t testing.T, path string) string {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Build
-	cmd := exec.Command("go", "build", "-o", "import-test")
+	// Build.  Note that when running on Windows systems the
+	// import will need an .EXE extension
+	buildOutput := "import-test"
+	if isWindows() {
+		buildOutput += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-o", buildOutput)
 	cmd.Dir = td
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -424,7 +431,11 @@ func buildImport(t testing.T, path string) string {
 	}
 
 	// Record it
-	importMap[path] = filepath.Join(td, "import-test")
+	importMap[path] = filepath.Join(td, buildOutput)
 	log.Printf("Import binary built at: %s", importMap[path])
 	return importMap[path]
+}
+
+func isWindows() bool {
+	return runtime.GOOS == "windows"
 }


### PR DESCRIPTION
Previous the testing framework would build the import without a .exe
extension on Windows. This meant that sentinel could not craft a
configuration which would make it execute the import file. In turn
this meant that the SDK could not be used to test imports on Windows
systems which is one of the use cases for this SDK

This commit updates the import builder to add the .exe extension
on Windows systems.