### PR TITLE
Remove deprecated set-output

### DIFF
--- a/.github/workflows/get-go-version.yml
+++ b/.github/workflows/get-go-version.yml
@@ -21,4 +21,4 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This commit removes the deprecated set-output command and instead uses the supported environment file [1]

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/