### PR TITLE
Add list interface

### DIFF
--- a/framework/interface.go
+++ b/framework/interface.go
@@ -121,6 +121,13 @@ type Map interface {
 	Map() (map[string]interface{}, error)
 }
 
+// List is a Namespace that supports returning a list of data.
+type List interface {
+	Namespace
+
+	List() ([]interface{}, error)
+}
+
 // Call is a Namespace that supports call expressions. For example, "time.now()"
 // would invoke the Func function for "now".
 type Call interface {

--- a/framework/plugin.go
+++ b/framework/plugin.go
@@ -237,6 +237,14 @@ func (m *Plugin) resultReflect(result interface{}) (interface{}, error) {
 		}
 	}
 
+	if l, ok := result.(List); ok {
+		var err error
+		result, err = l.List()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// We now need to do a bit of reflection to convert any dangling
 	// namespace values into values that can be returned across the
 	// plugin interface.

--- a/framework/plugin_test.go
+++ b/framework/plugin_test.go
@@ -350,6 +350,32 @@ var getCases = []struct {
 	},
 
 	{
+		"key get nested list",
+		&rootEmbedNamespace{&nsKeyValue{
+			Key: "foo",
+			Value: &nsList{
+				Value: []interface{}{"bar", "baz"},
+			},
+		}},
+		[]*sdk.GetReq{
+			{
+				Keys: []sdk.GetKey{
+					{Key: "foo"},
+				},
+				KeyId: 42,
+			},
+		},
+		[]*sdk.GetResult{
+			{
+				Keys:  []string{"foo"},
+				KeyId: 42,
+				Value: []interface{}{"bar", "baz"},
+			},
+		},
+		"",
+	},
+
+	{
 		"key get map value",
 		&rootEmbedNamespace{&nsKeyValue{
 			Key: "foo",
@@ -1494,6 +1520,18 @@ func (v *nsKeyValueMap) Get(key string) (interface{}, error) {
 }
 
 func (v *nsKeyValueMap) Map() (map[string]interface{}, error) {
+	return v.Value, nil
+}
+
+// nsList implements Namespace and returns a value by looking up
+// the index in a slice
+type nsList struct{ Value []interface{} }
+
+func (v *nsList) Get(key string) (interface{}, error) {
+	return nil, nil
+}
+
+func (v *nsList) List() ([]interface{}, error) {
 	return v.Value, nil
 }
 

--- a/framework/reflect.go
+++ b/framework/reflect.go
@@ -10,6 +10,7 @@ import (
 // various convenience types for reflect calls
 var (
 	mapTyp            = reflect.TypeOf((*Map)(nil)).Elem()
+	listTyp           = reflect.TypeOf((*List)(nil)).Elem()
 	interfaceTyp      = reflect.TypeOf((*interface{})(nil)).Elem()
 	sliceInterfaceTyp = reflect.TypeOf([]interface{}{})
 )
@@ -65,6 +66,15 @@ func (m *Plugin) reflectValue(v reflect.Value) (reflect.Value, error) {
 		}
 
 		v = reflect.ValueOf(m)
+	}
+
+	if v.Type().Implements(listTyp) {
+		l, err := v.Interface().(List).List()
+		if err != nil {
+			return v, err
+		}
+
+		v = reflect.ValueOf(l)
 	}
 
 	switch v.Kind() {
@@ -130,6 +140,7 @@ func (m *Plugin) reflectSlice(v reflect.Value) (reflect.Value, error) {
 	result := reflect.MakeSlice(sliceInterfaceTyp, v.Len(), v.Cap())
 	for i := 0; i < v.Len(); i++ {
 		elem := v.Index(i)
+
 		newElem, err := m.reflectValue(elem)
 		if err != nil {
 			return v, err


### PR DESCRIPTION
To help enable further capabilities within the SDK, this PR adds a `List` interface to allow namespaces to return a list of data.