### PR TITLE
TF-6589: Ensure import order is consistent throughout Sentinel repositories

### DIFF
--- a/rpc/plugin.go
+++ b/rpc/plugin.go
@@ -6,10 +6,12 @@ package rpc
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	goplugin "github.com/hashicorp/go-plugin"
+
 	sdk "github.com/hashicorp/sentinel-sdk"
 	proto "github.com/hashicorp/sentinel-sdk/proto/go"
-	"google.golang.org/grpc"
 )
 
 // Plugin is the goplugin.Plugin implementation to serve sdk.Plugin.

--- a/rpc/plugin_grpc_client.go
+++ b/rpc/plugin_grpc_client.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"math"
 
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
 	sdk "github.com/hashicorp/sentinel-sdk"
 	"github.com/hashicorp/sentinel-sdk/encoding"
 	proto "github.com/hashicorp/sentinel-sdk/proto/go"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 // PluginGRPCClient is a gRPC server for Plugins.

--- a/rpc/plugin_grpc_server.go
+++ b/rpc/plugin_grpc_server.go
@@ -11,10 +11,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	sdk "github.com/hashicorp/sentinel-sdk"
 	"github.com/hashicorp/sentinel-sdk/encoding"
 	proto "github.com/hashicorp/sentinel-sdk/proto/go"
-	"golang.org/x/net/context"
 )
 
 // PluginGRPCServer is a gRPC server for Plugins.

--- a/rpc/plugin_grpc_test.go
+++ b/rpc/plugin_grpc_test.go
@@ -7,8 +7,9 @@ import (
 	"reflect"
 	"testing"
 
-	sdk "github.com/hashicorp/sentinel-sdk"
 	"github.com/stretchr/testify/mock"
+
+	sdk "github.com/hashicorp/sentinel-sdk"
 )
 
 func TestPlugin_gRPC_configure(t *testing.T) {

--- a/rpc/plugin_test.go
+++ b/rpc/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	goplugin "github.com/hashicorp/go-plugin"
+
 	sdk "github.com/hashicorp/sentinel-sdk"
 )
 

--- a/rpc/serve.go
+++ b/rpc/serve.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	goplugin "github.com/hashicorp/go-plugin"
+
 	sdk "github.com/hashicorp/sentinel-sdk"
 )
 


### PR DESCRIPTION
CHANGELOG: Changed the import order for all the Go files in the sentinel-sdk repository.

## Description
Fixed the import order of the libraries used by all the Go files following the logic below:
- standard library
- 3rd party dependencies (not including hashicorp dependencies)
- hashicorp dependencies
- local dependencies

<!-- Describe why you're making this change. -->

## Testing plan
This change does not require any testing plan.

## External links
- [JIRA task](https://hashicorp.atlassian.net/browse/TF-6589)
