### PR TITLE
Add MarshalJSON for sdk.Null, ensuring conversion the same as Go nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test-results/
 .direnv
+.vscode

--- a/plugin.go
+++ b/plugin.go
@@ -9,6 +9,7 @@
 package sdk
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -25,6 +26,10 @@ var (
 	// By making this a return value, it will convert to null.
 	Null = &null{}
 )
+
+// MarshalJSON provides custom marshalling logic to the encoding/json
+// package, allowing for the null type to be marshalled as nil
+func (*null) MarshalJSON() ([]byte, error) { return json.Marshal(nil) }
 
 //go:generate rm -f mock_Plugin.go mock_Plugin_Closer.go
 //go:generate mockery --inpackage --note "Generated code. DO NOT MODIFY." --name=Plugin

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -4,6 +4,8 @@
 package sdk
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -39,5 +41,16 @@ func TestGetResultListKeyId(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", tc.Expected, actual)
 			}
 		})
+	}
+}
+
+func Test_Null_MarshalJSON(t *testing.T) {
+	res, err := json.Marshal(Null)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(res, []byte("null")) {
+		t.Fatalf("unexpected response, marshal of Null should be \"null\", got %q", string(res))
 	}
 }


### PR DESCRIPTION
Currently the `sdk.Null` type marshals as `{}` when using the `encoding/json` package. This PR will fix that so that it marshals to `null` as expected.